### PR TITLE
feat(chat): add stale user cleanup and improve disabled state styling

### DIFF
--- a/src/convex/_generated/api.d.ts
+++ b/src/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as auth from "../auth.js";
 import type * as chatRoomsInternal from "../chatRoomsInternal.js";
+import type * as crons from "../crons.js";
 import type * as http from "../http.js";
 import type * as messagesInternal from "../messagesInternal.js";
 import type * as mutations from "../mutations.js";
@@ -27,6 +28,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   chatRoomsInternal: typeof chatRoomsInternal;
+  crons: typeof crons;
   http: typeof http;
   messagesInternal: typeof messagesInternal;
   mutations: typeof mutations;

--- a/src/convex/crons.ts
+++ b/src/convex/crons.ts
@@ -1,0 +1,9 @@
+import { cronJobs } from 'convex/server';
+import { internal } from './_generated/api';
+
+const crons = cronJobs();
+
+// Run every minute to check for stale online users
+crons.interval('cleanup stale users', { minutes: 1 }, internal.usersInternal.cleanupStaleUsers);
+
+export default crons;

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -9,7 +9,9 @@ export default defineSchema({
 		avatarUrl: v.optional(v.string()),
 		createdAt: v.number(),
 		lastSeen: v.optional(v.number())
-	}).index('by_nickname', ['nickname']),
+	})
+		.index('by_nickname', ['nickname'])
+		.index('by_status', ['status']),
 
 	sessions: defineTable({
 		tokenHash: v.string(), // SHA-256 hash of the session token

--- a/src/convex/usersInternal.ts
+++ b/src/convex/usersInternal.ts
@@ -93,3 +93,32 @@ export const setAllOffline = internalMutation({
 		return { updated: users.length };
 	}
 });
+
+// Cleanup stale users who haven't sent a heartbeat in 2 minutes
+export const cleanupStaleUsers = internalMutation({
+	args: {},
+	handler: async (ctx) => {
+		const ONLINE_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
+		const timeoutThreshold = Date.now() - ONLINE_TIMEOUT_MS;
+
+		const nonOfflineStatuses = ['online', 'away', 'busy', 'idle'];
+		let updated = 0;
+
+		for (const status of nonOfflineStatuses) {
+			const users = await ctx.db
+				.query('users')
+				.withIndex('by_status', (q) => q.eq('status', status))
+				.collect();
+
+			for (const user of users) {
+				const lastSeen = user.lastSeen ?? 0;
+				if (lastSeen < timeoutThreshold) {
+					await ctx.db.patch(user._id, { status: 'offline' });
+					updated++;
+				}
+			}
+		}
+
+		return { updated };
+	}
+});

--- a/src/lib/components/chat-room.svelte
+++ b/src/lib/components/chat-room.svelte
@@ -1143,7 +1143,7 @@
 						</div>
 					{/if}
 
-					<div class="field-row input-container" style="margin: 0;">
+					<div class="field-row input-container" style="margin: 0; position: relative;">
 						{#if currentTextStyle.gradient && currentTextStyle.gradient.length > 1}
 							<div
 								class="gradient-input-wrapper"
@@ -1184,7 +1184,7 @@
 									bind:value={currentMessage}
 									maxlength={MAX_MESSAGE_LENGTH}
 									class="styled-input retro-font-{currentTextStyle.fontFamily}"
-									style="width: 100%; background: transparent; color: transparent; caret-color: black; font-size: {currentTextStyle.fontSize}px; {currentTextStyle.bold
+									style="width: 100%; background: transparent; color: transparent; caret-color: black; font-size: {currentTextStyle.fontSize}px; padding-left: 3px; {currentTextStyle.bold
 										? currentTextStyle.fontFamily === 'tahoma'
 											? 'font-weight: 200;'
 											: 'font-weight: 700;'
@@ -1200,9 +1200,11 @@
 									onfocus={handleInputFocus}
 									onclick={handleInputClick}
 									bind:this={messageInput}
-									placeholder={cooldownEndTime
-										? `Patientez ${cooldownProgress.toFixed(1)}s...`
-										: 'Écrivez un message...'}
+									placeholder={!currentUser
+										? 'Inscris-toi pour participer.'
+										: cooldownEndTime
+											? `Patientez ${cooldownProgress.toFixed(1)}s...`
+											: 'Écrivez un message...'}
 									disabled={!currentUser || Boolean(cooldownEndTime)}
 									role="combobox"
 									aria-autocomplete="list"
@@ -1247,7 +1249,7 @@
 									bind:value={currentMessage}
 									maxlength={MAX_MESSAGE_LENGTH}
 									class="styled-input mention-overlay-input retro-font-{currentTextStyle.fontFamily}"
-									style="width: 100%; background: transparent; color: transparent; font-size: {currentTextStyle.fontSize}px; {currentTextStyle.bold
+									style="width: 100%; background: transparent; color: transparent; font-size: {currentTextStyle.fontSize}px; padding-left: 3px; {currentTextStyle.bold
 										? currentTextStyle.fontFamily === 'tahoma'
 											? 'font-weight: 200;'
 											: 'font-weight: 700;'
@@ -1263,9 +1265,11 @@
 									onfocus={handleInputFocus}
 									onclick={handleInputClick}
 									bind:this={messageInput}
-									placeholder={cooldownEndTime
-										? `Patientez ${cooldownProgress.toFixed(1)}s...`
-										: 'Écrivez un message...'}
+									placeholder={!currentUser
+										? 'Inscris-toi pour participer.'
+										: cooldownEndTime
+											? `Patientez ${cooldownProgress.toFixed(1)}s...`
+											: 'Écrivez un message...'}
 									disabled={!currentUser || Boolean(cooldownEndTime)}
 									role="combobox"
 									aria-autocomplete="list"
@@ -1547,8 +1551,15 @@
 
 	.input-container input:disabled {
 		opacity: 0.7;
-		background-color: rgba(128, 128, 128, 0.1);
+		background-color: rgba(128, 128, 128, 0.3) !important;
 		cursor: not-allowed;
+	}
+
+	/* Fade input wrapper when disabled */
+	.input-container:has(input:disabled) .gradient-input-wrapper,
+	.input-container:has(input:disabled) .mention-input-wrapper {
+		opacity: 0.6;
+		background-color: #f0f0f0 !important;
 	}
 
 	.hidden {

--- a/src/lib/components/ui/button-loading.svelte
+++ b/src/lib/components/ui/button-loading.svelte
@@ -78,6 +78,7 @@
 	}
 	button:disabled {
 		cursor: not-allowed;
-		opacity: 0.7;
+		opacity: 0.5;
+		filter: grayscale(50%);
 	}
 </style>


### PR DESCRIPTION
## Summary
- Add cleanupStaleUsers mutation for automatic offline status after 2 minutes
- Add crons module for scheduled tasks
- Improve input placeholder messaging for non-authenticated users  
- Enhance disabled state styling for buttons and inputs with better visual feedback

## Changes
- New `cleanupStaleUsers` mutation in `usersInternal.ts`
- New `crons.ts` module for scheduled tasks
- Updated chat input placeholders and styling
- Improved button disabled state appearance